### PR TITLE
RenderTextToLengthByPosition: store in correct registers

### DIFF
--- a/gingerbread.asm
+++ b/gingerbread.asm
@@ -496,7 +496,7 @@ RenderTextToLengthByPosition:
 
     ; Now store this onto DE so we can get the read address back again
     ld d, h
-    ld l, e
+    ld e, l
     pop hl
 
     di

--- a/gingerbread.asm
+++ b/gingerbread.asm
@@ -1,14 +1,14 @@
 ; GingerBread is a kind of standard library for Game Boy games written in assembly
-; using the RGBDS system. It intends to provide basic functionality that almost 
+; using the RGBDS system. It intends to provide basic functionality that almost
 ; every game will need in one form or another. It is meant to be used alongside the
 ; book "Game Boy Assembly Programming for the Modern Game Developer", available
-; here: https://teamlampoil.se/book/gbasmdev.pdf 
+; here: https://teamlampoil.se/book/gbasmdev.pdf
 ; The book also works as a form of documentation for this library.
 
 ; --- ROM Header ---
 
 ; Before importing gingerbread.asm, you can specify the following options to affect the game header
-IF !DEF(GAME_NAME)    
+IF !DEF(GAME_NAME)
 GAME_NAME EQUS "GINGERBREAD"
 ENDC
 
@@ -31,7 +31,7 @@ ENDC
 IF !DEF(RAM_SIZE)
 RAM_SIZE EQU 1
 ENDC
-    
+
 SECTION "header",ROM0[$0104]
 
     ; "Nintendo" logo. If this is modified, the game won't start on a real Gameboy.
@@ -39,11 +39,11 @@ SECTION "header",ROM0[$0104]
     DB $00,$08,$11,$1F,$88,$89,$00,$0E,$DC,$CC,$6E,$E6,$DD,$DD,$D9,$99
     DB $BB,$BB,$67,$63,$6E,$0E,$EC,$CC,$DD,$DC,$99,$9F,$BB,$B9,$33,$3E
 
-    ; The header, specifying ROM details. 
+    ; The header, specifying ROM details.
     DB {GAME_NAME}          ; $134 - Title of the game, in uppercase ASCII. Should be exactly 15 characters (padded with 0s if necessary)
 REPT 15-STRLEN({GAME_NAME})
     DB 0
-ENDR    
+ENDR
     DB 	H_GBC_CODE          ; $143 - GBC functionality (0 for no, $80 for "black cart" and $C0 for GBC only)
     DB 	0,0                 ; $144 - Licensee code (not important)
     DB 	H_SGB_CODE          ; $146 - SGB Support indicator (0 means no support, 3 means there is SGB support in the game)
@@ -59,7 +59,7 @@ ENDR
 
 ; --- Hardware constants ---
 
-; General 
+; General
 ROM_BANK_SWITCH     EQU $2000
 SAVEDATA            EQU $0000
 MBC5_RAMB           EQU $4000
@@ -79,7 +79,7 @@ BG_PALETTE       EQU $FF47
 SPRITE_PALETTE_1 EQU $FF48
 SPRITE_PALETTE_2 EQU $FF49
 
-; GBC palettes 
+; GBC palettes
 GBC_BG_PALETTE_INDEX      EQU $FF68
 GBC_BG_PALETTE            EQU $FF69
 GBC_SPRITE_PALETTE_INDEX  EQU $FF6A
@@ -133,7 +133,7 @@ IEF_TIMER   EQU  %00000100 ; Timer Overflow
 IEF_LCDC    EQU  %00000010 ; LCDC
 IEF_VBLANK  EQU  %00000001 ; V-Blank
 
-; LCD stuff 
+; LCD stuff
 rLCDC EQU $FF40
 
 LCDCF_OFF     EQU  %00000000 ; LCD Control Operation
@@ -153,40 +153,40 @@ LCDCF_OBJON   EQU  %00000010 ; OBJ Display
 LCDCF_BGOFF   EQU  %00000000 ; BG Display
 LCDCF_BGON    EQU  %00000001 ; BG Display
 
-; Sound stuff 
+; Sound stuff
 SOUND_VOLUME    EQU $FF24
 SOUND_OUTPUTS   EQU $FF25
 SOUND_ONOFF     EQU $FF26
 
 ; Channel 1 (square with sweep and enevelope effects)
 SOUND_CH1_START     EQU $FF10 ; bit 7: unused, bits 6-4: sweep time, bit 3: sweep frequency increase/decrease, bits 2-0: number of sweep shifts
-SOUND_CH1_LENGTH    EQU $FF11 ; bits 7-6: wave duty, bits 5-0: length of sound data 
+SOUND_CH1_LENGTH    EQU $FF11 ; bits 7-6: wave duty, bits 5-0: length of sound data
 SOUND_CH1_ENVELOPE  EQU $FF12 ; bits 7-4: start value for envelope, bit 3: envelope decrease/increase, bits 2-0: number of envelope sweeps
-SOUND_CH1_LOWFREQ   EQU $FF13 ; bits 7-0: lower 8 bits of the sound frequency 
+SOUND_CH1_LOWFREQ   EQU $FF13 ; bits 7-0: lower 8 bits of the sound frequency
 SOUND_CH1_HIGHFREQ  EQU $FF14 ; bit 7: restart channel, bit 6: use length, bits 5-3: unused, bits 2-0: highest 3 bits of frequency
 
 ; Channel 2 (square with enevelope effect, with no sweep effect)
-SOUND_CH2_START     EQU $FF15 ; Not used but you can write zeroes here 
-SOUND_CH2_LENGTH    EQU $FF16 ; bits 7-6: wave duty, bits 5-0: length of sound data 
+SOUND_CH2_START     EQU $FF15 ; Not used but you can write zeroes here
+SOUND_CH2_LENGTH    EQU $FF16 ; bits 7-6: wave duty, bits 5-0: length of sound data
 SOUND_CH2_ENVELOPE  EQU $FF17 ; bits 7-4: start value for envelope, bit 3: envelope decrease/increase, bits 2-0: number of envelope sweeps
-SOUND_CH2_LOWFREQ   EQU $FF18 ; bits 7-0: lower 8 bits of the sound frequency 
+SOUND_CH2_LOWFREQ   EQU $FF18 ; bits 7-0: lower 8 bits of the sound frequency
 SOUND_CH2_HIGHFREQ  EQU $FF19 ; bit 7: restart channel, bit 6: use length, bits 5-3: unused, bits 2-0: highest 3 bits of frequency
 
 ; Channel 3 (custom wave)
-SOUND_CH3_START     EQU $FF1A ; bit 7: on/off, bits 6-0: unused 
-SOUND_CH3_LENGTH    EQU $FF1B ; bits 7-0: length of sound 
+SOUND_CH3_START     EQU $FF1A ; bit 7: on/off, bits 6-0: unused
+SOUND_CH3_LENGTH    EQU $FF1B ; bits 7-0: length of sound
 SOUND_CH3_VOLUME    EQU $FF1C ; bits 6-5: audio volume (%00 is mute, %01 is loudest, %10 is pretty quiet and %11 is very quiet)
 SOUND_CH3_LOWFREQ   EQU $FF1D ; bits 7-0: lower 8 bits of the sound frequency
 SOUND_CH3_HIGHFREQ  EQU $FF1E ; bit 7: restart channel, bit 6: use length, bits 5-3: unused, bits 2-0: highest 3 bits of frequency
 
 ; Channel 4 (noise)
-SOUND_CH4_START     EQU $FF1F ; Not used but you can write zeroes here 
-SOUND_CH4_LENGTH    EQU $FF20 ; bits 5-0: length of sound 
+SOUND_CH4_START     EQU $FF1F ; Not used but you can write zeroes here
+SOUND_CH4_LENGTH    EQU $FF20 ; bits 5-0: length of sound
 SOUND_CH4_ENVELOPE  EQU $FF21 ; bits 7-4: start value for envelope, bit 3: envelope decrease/increase, bits 2-0: number of envelope sweeps
 SOUND_CH4_POLY      EQU $FF22 ; bits 7-4: polynomial counter, bit 3: number of steps (15 or 7), bits 2-0: ratio of frequency division (%000 gives highest frequency, %111 the lowest)
 SOUND_CH4_OPTIONS   EQU $FF23 ; bit 7: restart channel, bit 6: use length
 
-; Wave table for Channel 3 
+; Wave table for Channel 3
 SOUND_WAVE_TABLE_START EQU $FF30
 SOUND_WAVE_TABLE_STOP  EQU $FF3F
 
@@ -199,8 +199,8 @@ rDMA  EQU $FF46
 ; GingerBread writes a few variables in RAM between $C100 and $C1FF. Let your own RAM usage start at $C200 to make sure none of your code messes with GingerBread
 ; $C100 - $C1A0 are used for sprites, so these start after that. The space between $C000-$C1000 is used by GBT-Player.
 SECTION "GingerBread RAM variables",WRAM0[$C1A1]
-RUNNING_ON_SGB: DS 1 
-RUNNING_ON_GBC: DS 1 
+RUNNING_ON_SGB: DS 1
+RUNNING_ON_GBC: DS 1
 
 
 ; --- Standard functions ---
@@ -212,19 +212,19 @@ SECTION "GingerBreadKeypad",ROM0
 ; The code is copied from the Gameboy Programming Manual, http://www.chrisantonellis.com/files/gameboy/gb-programming-manual.pdf
 ReadKeys:
     push bc
-    
+
     ; Read D-pad
 	ld a, $20
-    ld [$FF00], a 
+    ld [$FF00], a
     ld a, [$FF00]
     ld a, [$FF00]
     cpl
     and %00001111
-    ld b, a 
-    
+    ld b, a
+
     ; Read buttons (Start, Select, B, A)
     ld a, $10
-    ld [$FF00], a 
+    ld [$FF00], a
     ld a, [$FF00]
     ld a, [$FF00]
     ld a, [$FF00]
@@ -233,88 +233,88 @@ ReadKeys:
     ld a, [$FF00]
     cpl
     and %00001111
-    
+
     ; Combine D-pad with buttons, store in B
-    swap a 
-    or b 
-    ld b, a 
-    
+    swap a
+    or b
+    ld b, a
+
     ld a, $30
     ld [$FF00], a
-    
+
     ; Return the stored result
     ld a, b
-    
-    pop bc 
+
+    pop bc
     ret
 
-Section "GingerBreadSound",ROM0 
-; Enables audio on all channels, at maximum output volume. 
-; Overwrites AF 
+Section "GingerBreadSound",ROM0
+; Enables audio on all channels, at maximum output volume.
+; Overwrites AF
 EnableAudio:
     ld a, %11111111
-    ld [SOUND_VOLUME],  a ; Max out the audio volume 
+    ld [SOUND_VOLUME],  a ; Max out the audio volume
     ld [SOUND_OUTPUTS], a ; Output all channels to both left/right speakers (when using headphones)
-    ld [SOUND_ONOFF],   a ; Turn audio on 
-    
-    ret 
+    ld [SOUND_ONOFF],   a ; Turn audio on
 
-; Use this if your game doesn't use audio, to save some battery life 
-; Overwrites AF     
-DisableAudio: 
-    xor a 
-    ld [SOUND_VOLUME],  a ; Turn off the audio volume 
+    ret
+
+; Use this if your game doesn't use audio, to save some battery life
+; Overwrites AF
+DisableAudio:
+    xor a
+    ld [SOUND_VOLUME],  a ; Turn off the audio volume
     ld [SOUND_OUTPUTS], a ; Output no channels to no left/right speakers (when using headphones)
-    ld [SOUND_ONOFF],   a ; Turn audio off 
-    
-    ret 
-    
+    ld [SOUND_ONOFF],   a ; Turn audio off
+
+    ret
+
 ; HL should point to a table which first contains a DW with either SOUND_CH1_START, SOUND_CH2_START, SOUND_CH3_START or SOUND_CH4_START
 ; followed by five values to be written to those addresses (see comments by the definitions of those constants)
-; Overwrites AF and HL 
-PlaySoundHL: 
-    push de 
-    
-    ; Read channel start into DE 
+; Overwrites AF and HL
+PlaySoundHL:
+    push de
+
+    ; Read channel start into DE
     ld a, [hl+]
-    ld e, a 
+    ld e, a
     ld a, [hl+]
-    ld d, a 
-    
-    ; Read data from table and feed into the channel start 
-    ld a, [hl+] 
+    ld d, a
+
+    ; Read data from table and feed into the channel start
+    ld a, [hl+]
     ld [de], a
-    inc de 
-    
-    ld a, [hl+]
-    ld [de], a 
     inc de
-    
-    ld a, [hl+]
-    ld [de], a 
-    inc de 
-    
+
     ld a, [hl+]
     ld [de], a
-    inc de 
+    inc de
+
+    ld a, [hl+]
+    ld [de], a
+    inc de
+
+    ld a, [hl+]
+    ld [de], a
+    inc de
 
     ld a, [hl]
-    ld [de], a 
-    
-    pop de 
-    ret 
-    
+    ld [de], a
+
+    pop de
+    ret
+
 Section "GingerBreadMemory",ROM0
 WaitForNonBusyLCD: MACRO
-    ld  a,[rSTAT]   
-    and STATF_BUSY  
+    ld  a,[rSTAT]
+    and STATF_BUSY
     jr  nz,@-4     ; Jumps up 4 bytes in the code (two lines in this case)
 ENDM
 
 WaitForNonBusyLCDSafeA: MACRO
-    push af 
+    push af
     WaitForNonBusyLCD
-    pop af 
+    pop af
 ENDM
 
 ; Copies data in a way that is safe to use when reading/writing to/from VRAM while LCD is on (but slower than mCopy)
@@ -330,7 +330,7 @@ mCopyVRAM:
         ; This "WaitForNonBusyLCD" here, along with the disabled interrupts, makes it safe to read/write to/from VRAM when LCD is on
         ; Essentially, we're waiting for the LCD to be non-busy before reading/writing. If we don't do this, we can
         ; read/write when the LCD is busy which results in corrupted data.
-        WaitForNonBusyLCD 
+        WaitForNonBusyLCD
         ld a, [hl+]
         ld [de], a
     ei
@@ -341,7 +341,7 @@ mCopyVRAM:
     dec b
     jr nz, .loop
     ret
-    
+
 ; Copies data in a way that is NOT safe to use when reading/writing to/from VRAM while LCD is on (but faster than mCopyVRAM)
 ; HL - memory position of the start of the copying source
 ; DE - memory position of the start of the copying destination
@@ -360,19 +360,19 @@ mCopy:
     dec b
     jr nz, .loop
     ret
-    
+
 ; Sets data to a constant value in a way that is safe to use when writing to VRAM while LCD is on (but slower than mSet)
 ; A  - constant value to set
 ; HL - memory position of the start of the copying destination
-; BC - the number of bytes to be written 
+; BC - the number of bytes to be written
 mSetVRAM:
     inc b
     inc c
     jr  .skip
 .loop:
     di
-        WaitForNonBusyLCDSafeA 
-        ld [hl+], a 
+        WaitForNonBusyLCDSafeA
+        ld [hl+], a
     ei
 .skip:
     dec c
@@ -380,353 +380,353 @@ mSetVRAM:
     dec b
     jr nz, .loop
     ret
-    
+
 ; Sets data to a constant value in a way that is NOT safe to use when writing to VRAM while LCD is on (but faster than mSetVRAM)
 ; A  - constant value to set
 ; HL - memory position of the start of the copying destination
-; BC - the number of bytes to be written 
+; BC - the number of bytes to be written
 mSet:
     inc b
     inc c
     jr  .skip
 .loop:
-    ld [hl+], a 
+    ld [hl+], a
 .skip:
     dec c
     jr  nz, .loop
     dec b
     jr nz, .loop
     ret
-    
+
 
 ; --- Text and number display ---
 
 ; Draws text until a specific end character appears, using X/Y coordinates, which can be a bit slower than RenderTextToEndByPosition
 ; B - tile number of end character
-; C - zero if drawn to background, non-zero if drawn to window 
+; C - zero if drawn to background, non-zero if drawn to window
 ; D - X position
-; E - Y position 
-; HL - address to start of the text to write, make sure it contains the end character somewhere 
+; E - Y position
+; HL - address to start of the text to write, make sure it contains the end character somewhere
 RenderTextToEnd:
-    ; Convert position coordinates to position number  
-    push hl 
-    
-    xor a 
-    ld h, a
-    ld l, a 
-    call XYtoPosition
-    
-    ; Put position number at DE and then restore HL 
-    ld d, h 
-    ld e, l  
-    pop hl 
-    
-    call RenderTextToEndByPosition
-    ret     
+    ; Convert position coordinates to position number
+    push hl
 
-; Draws text until a specific end character appears, using a position number which is faster than RenderTextToEnd if the number is precomputed at compile time 
-; B - tile number of end character
-; C - zero if drawn to background, non-zero if drawn to window 
-; DE - position number to start writing at 
-; HL - address to start of the text to write, make sure it contains the end character somewhere 
-RenderTextToEndByPosition:
-    ; For now, HL will store the address to write to, which we'll have to compute 
-    push hl 
-    call InitializePositionForBackgroundOrWindow
-    add hl, de 
-    
-    ; Move this address onto DE so we can get the text address back 
+    xor a
+    ld h, a
+    ld l, a
+    call XYtoPosition
+
+    ; Put position number at DE and then restore HL
     ld d, h
-    ld e, l 
-    pop hl 
-    
+    ld e, l
+    pop hl
+
+    call RenderTextToEndByPosition
+    ret
+
+; Draws text until a specific end character appears, using a position number which is faster than RenderTextToEnd if the number is precomputed at compile time
+; B - tile number of end character
+; C - zero if drawn to background, non-zero if drawn to window
+; DE - position number to start writing at
+; HL - address to start of the text to write, make sure it contains the end character somewhere
+RenderTextToEndByPosition:
+    ; For now, HL will store the address to write to, which we'll have to compute
+    push hl
+    call InitializePositionForBackgroundOrWindow
+    add hl, de
+
+    ; Move this address onto DE so we can get the text address back
+    ld d, h
+    ld e, l
+    pop hl
+
     di
-    
+
     ; Start writing
     ld a, [hl]
 .draw:
     WaitForNonBusyLCDSafeA
-    ld [de], a 
-    inc de 
-    
-    ; Check if the next character is the end character 
-    inc hl 
+    ld [de], a
+    inc de
+
+    ; Check if the next character is the end character
+    inc hl
     ld a, [hl]
-    cp b 
-    jr nz, .draw 
-    
-    reti 
-    
+    cp b
+    jr nz, .draw
+
+    reti
+
 ; Draws text until a certain number of characters have been written, with positions as X/Y coordinates. This might be a bit slow for repeated use every frame.
-; B - number of characters to write 
-; C - drawing to background (0) or window (1) 
-; D - X position 
-; E - Y position 
-; HL - address to start of text to write 
+; B - number of characters to write
+; C - drawing to background (0) or window (1)
+; D - X position
+; E - Y position
+; HL - address to start of text to write
 RenderTextToLength:
-    ; Convert position coordinates to position number  
-    push hl 
-    
-    xor a 
+    ; Convert position coordinates to position number
+    push hl
+
+    xor a
     ld h, a
-    ld l, a 
+    ld l, a
     call XYtoPosition
-    
-    ; Put position number at DE and then restore HL 
-    ld d, h 
-    ld e, l  
-    pop hl 
-    
+
+    ; Put position number at DE and then restore HL
+    ld d, h
+    ld e, l
+    pop hl
+
     call RenderTextToLengthByPosition
-    ret 
+    ret
 
 ; Draws text until a certain number of characters have been writtens, with position numbers using the formula pos = x + y*32
 ; If position numbers are precomputed at compile time, this will execute faster than RenderTextToLength
-; B - number of characters to write 
+; B - number of characters to write
 ; C - drawing to background (zero) or window (non-zero)
-; DE - position number 
-; HL - address to start of text to write 
+; DE - position number
+; HL - address to start of text to write
 RenderTextToLengthByPosition:
-    push hl 
-    ; For now, HL will store the position to write to 
+    push hl
+    ; For now, HL will store the position to write to
     call InitializePositionForBackgroundOrWindow
-    
+
     ; Add starting position onto background/window
-    add hl, de 
-    
-    ; Now store this onto DE so we can get the read address back again 
+    add hl, de
+
+    ; Now store this onto DE so we can get the read address back again
     ld d, h
-    ld l, e 
-    pop hl 
-    
+    ld l, e
+    pop hl
+
     di
 .draw:
     ; Write characters until B is zero, decreasing it every time
     ld a, [hl+]
-    WaitForNonBusyLCDSafeA ; Writing to VRAM needs to be timed 
-    ld [de], a 
-    inc de 
-    
-    dec b 
-    ; Is B zero? If so we should stop 
-    ld a, b 
-    cp 0 
-    jr z, .finish 
-    
+    WaitForNonBusyLCDSafeA ; Writing to VRAM needs to be timed
+    ld [de], a
+    inc de
+
+    dec b
+    ; Is B zero? If so we should stop
+    ld a, b
+    cp 0
+    jr z, .finish
+
     jr .draw
 
 .finish:
-    ei 
-    ret 
-    
-; Internal function 
-; Converts X and Y coordinates to a single position number by the formula pos = x + 32*y 
-; D - X position 
-; E - Y position 
+    ei
+    ret
+
+; Internal function
+; Converts X and Y coordinates to a single position number by the formula pos = x + 32*y
+; D - X position
+; E - Y position
 ; Output is added onto HL (which may be non-zero initially)
-; Overwrites A 
+; Overwrites A
 XYtoPosition:
-    ; Addition of 16-bit numbers require a full other 16-bit number to add. So we use BC for that here 
-    push bc 
-    
-    ; Add X-position 
-    ld c, d 
-    ld b, 0 
-    ; Now BC contains the X value as a 16-bit number 
-    
-    add hl, bc 
-    
+    ; Addition of 16-bit numbers require a full other 16-bit number to add. So we use BC for that here
+    push bc
+
+    ; Add X-position
+    ld c, d
+    ld b, 0
+    ; Now BC contains the X value as a 16-bit number
+
+    add hl, bc
+
     ; Add Y-position if y>0
-    ld a, e 
-    cp 0 
-    jr z, .end 
-    
-    ld c, e 
-    ; Each line on the background/window is 32 tiles long, so to convert this to number of lines, we add the Y value 32 times) 
+    ld a, e
+    cp 0
+    jr z, .end
+
+    ld c, e
+    ; Each line on the background/window is 32 tiles long, so to convert this to number of lines, we add the Y value 32 times)
     REPT 32
-    add hl, bc 
-    ENDR 
-    
+    add hl, bc
+    ENDR
+
 .end:
-    pop bc 
-    ret 
+    pop bc
+    ret
 
 ; Draws two decimal (base 10) numbers, stored in a single 8-bit number (for example $42 would represent 42)
-; A - The two numbers 
+; A - The two numbers
 ; B - Tile number of 0 (assuming that the rest of the digits follow, precisely in the order 0123456789)
 ; C - Zero if writing to background, non-zero if writing to window
 ; D - X position to write
 ; E - Y position to write
-RenderTwoDecimalNumbers:     
-    push af 
-    push hl 
-    
-    ; Reset HL 
-    xor a 
-    ld h, a 
-    ld l, a 
-    
+RenderTwoDecimalNumbers:
+    push af
+    push hl
+
+    ; Reset HL
+    xor a
+    ld h, a
+    ld l, a
+
     call XYtoPosition
-    
+
     ; The ByPosition call below expects the position number (now on HL) to be on DE
     ld d, h
-    ld e, l 
-    
-    pop hl 
-    pop af 
-    
+    ld e, l
+
+    pop hl
+    pop af
+
     call RenderTwoDecimalNumbersByPosition
 
-    ret 
+    ret
 
-; Internal function 
+; Internal function
 ; Sets HL to either the start of background map data or window map data, depending on C
-; C - zero for background, non-zero for window 
+; C - zero for background, non-zero for window
 InitializePositionForBackgroundOrWindow:
-    ld a, c 
-    cp 0 
+    ld a, c
+    cp 0
     jr nz, .useWindow
-    
+
 .useBackground:
     ld hl, BACKGROUND_MAPDATA_START
     ret
-    
-.useWindow:    
+
+.useWindow:
     ld hl, WINDOW_MAPDATA_START
-    ret 
-    
+    ret
+
 ; Draws two decimal (base 10) numbers, stored in a single 8-bit number (for example $42 would represent 42)
-; Unlike RenderTwoDecimalNumbers, the position input here is a position number. This executes faster if the number is precomputed 
+; Unlike RenderTwoDecimalNumbers, the position input here is a position number. This executes faster if the number is precomputed
 ; and is thus recommended if the game displays lots of text and/or numbers every frame.
-; A - The two numbers 
+; A - The two numbers
 ; B - Tile number of 0 (assuming that the rest of the digits follow, precisely in the order 0123456789)
 ; C - Zero if writing to background, non-zero if writing to window
-; DE - Position number   
+; DE - Position number
 RenderTwoDecimalNumbersByPosition:
-    push hl ; Use HL for temporary storage 
+    push hl ; Use HL for temporary storage
     push af ; To store the original two numbers to write
-    
-    ; Set HL to base address for background/window depending on value in C 
-    call InitializePositionForBackgroundOrWindow
-    
-.draw:    
-    ; To get the correct position, we add the position number onto HL  
-    add hl, de 
 
-    pop af 
-    
-    ; We don't need C anymore so we can use it to temporarily store the two numbers to write 
-    ld c, a 
-    
-    ; Get the leftmost number first 
+    ; Set HL to base address for background/window depending on value in C
+    call InitializePositionForBackgroundOrWindow
+
+.draw:
+    ; To get the correct position, we add the position number onto HL
+    add hl, de
+
+    pop af
+
+    ; We don't need C anymore so we can use it to temporarily store the two numbers to write
+    ld c, a
+
+    ; Get the leftmost number first
     and %11110000
-    swap a 
-    
-    ; Convert to tile number 
-    add b 
-    
-    di
-    
-    ; Write the number 
-    WaitForNonBusyLCDSafeA
-    ld [hl+], a 
-    
-    ; Get the rightmost number 
-    ld a, c 
-    and %00001111
-    
-    ; Convert to tile number 
+    swap a
+
+    ; Convert to tile number
     add b
-    
-    ; Write the number 
+
+    di
+
+    ; Write the number
     WaitForNonBusyLCDSafeA
-    ld [hl], a 
-    
-    pop hl 
-    reti 
+    ld [hl+], a
+
+    ; Get the rightmost number
+    ld a, c
+    and %00001111
+
+    ; Convert to tile number
+    add b
+
+    ; Write the number
+    WaitForNonBusyLCDSafeA
+    ld [hl], a
+
+    pop hl
+    reti
 
 ; Draws four decimal (base 10) numbers, stored in a 16-bit number (for example $1234 would represent 1234)
-; HL - The four numbers 
+; HL - The four numbers
 ; B - Tile number of 0 (assuming that the rest of the digits follow, precisely in the order 0123456789)
 ; C - Zero if writing to background, non-zero if writing to window
 ; D - X position to write
-; E - Y position to write    
+; E - Y position to write
 RenderFourDecimalNumbers:
-    ; Write the leftmost numbers first 
+    ; Write the leftmost numbers first
     ld a, h
-    
-    push bc 
-    push de 
-    push hl 
-    
+
+    push bc
+    push de
+    push hl
+
     call RenderTwoDecimalNumbers
-    
-    pop hl 
-    pop de 
-    pop bc 
-    
-    ; Move "x" two steps to the right 
+
+    pop hl
+    pop de
+    pop bc
+
+    ; Move "x" two steps to the right
     inc d
     inc d
-    
+
     ; Then draw the rightmost numbers
-    ld a, l 
+    ld a, l
     call RenderTwoDecimalNumbers
-    
-    ret 
+
+    ret
 
 ; Draws four decimal (base 10) numbers, stored in a 16-bit number (for example $1234 would represent 1234)
-; Unlike RenderFourDecimalNumbers, this function uses position numbers computed by pos = x + 32*y which will be 
+; Unlike RenderFourDecimalNumbers, this function uses position numbers computed by pos = x + 32*y which will be
 ; faster if this number is precomputed.
-; HL - The four numbers 
+; HL - The four numbers
 ; B - Tile number of 0 (assuming that the rest of the digits follow, precisely in the order 0123456789)
 ; C - Zero if writing to background, non-zero if writing to window
-; DE - Position number of first number     
+; DE - Position number of first number
 RenderFourDecimalNumbersByPosition:
-    ld a, h ; The leftmost two numbers 
-    
-    push bc 
-    push de 
-    push hl 
-    
+    ld a, h ; The leftmost two numbers
+
+    push bc
+    push de
+    push hl
+
     call RenderTwoDecimalNumbersByPosition
-    
-    pop hl 
-    pop de 
-    pop bc 
-    
-    ; Move position two steps to the right 
-    inc de 
-    inc de 
-    
-    ld a, l ; The rightmost two numbers 
+
+    pop hl
+    pop de
+    pop bc
+
+    ; Move position two steps to the right
+    inc de
+    inc de
+
+    ld a, l ; The rightmost two numbers
     call RenderTwoDecimalNumbersByPosition
-    
-    ret 
-    
+
+    ret
+
 ; --- Save data ---
 
-; Allows save data to become accessible to read and write. Note that save data is disabled by default. It also must be supported by 
+; Allows save data to become accessible to read and write. Note that save data is disabled by default. It also must be supported by
 ; your cartidge and game header for this to work.
 EnableSaveData:
     ld a, $0A
-    ld [SAVEDATA], a 
-    
-    ret  
-
-; Disables save data. Do this as soon as you are done using SRAM, to prevent data loss in case of a crash.    
-DisableSaveData:
-    xor a 
     ld [SAVEDATA], a
-    
-    ret 
+
+    ret
+
+; Disables save data. Do this as soon as you are done using SRAM, to prevent data loss in case of a crash.
+DisableSaveData:
+    xor a
+    ld [SAVEDATA], a
+
+    ret
 
 ; Assuming your game uses MBC5, having different numbers on A (between $00 and $0F) will activate different
-; save data banks. Do this before running EnableSaveData.    
+; save data banks. Do this before running EnableSaveData.
 ChooseSaveDataBank:
-    ld [MBC5_RAMB], a 
-    
-    ret 
+    ld [MBC5_RAMB], a
+
+    ret
 
 ; --- Game Boy Color functionality ---
 IF DEF(GBC_SUPPORT)
@@ -735,64 +735,64 @@ SECTION "GBC commands",ROM0
 
 GBCEarlyExit: MACRO
     ld a, [RUNNING_ON_GBC]
-    cp 0 
+    cp 0
     ret z
 ENDM
 
-; HL - address pointing to a table of colors 
+; HL - address pointing to a table of colors
 ; A - palette byte to start writing at (each palette is eight bytes, two for each of the four colors, and there are eight palettes)
-; B - number of bytes to write 
+; B - number of bytes to write
 GBCApplyBackgroundPalettes:
     ; We use auto-increment for simplicity
     or %10000000
-    
-    ld [GBC_BG_PALETTE_INDEX], a 
-    
-.writeByte:   
-    
+
+    ld [GBC_BG_PALETTE_INDEX], a
+
+.writeByte:
+
     ld a, [hl]
-    ld [GBC_BG_PALETTE], a 
-    inc hl 
-    
+    ld [GBC_BG_PALETTE], a
+    inc hl
+
     ; Have we finished writing?
-    dec b 
-    ld a, b 
+    dec b
+    ld a, b
     cp 0 ; Is B equal to zero?
-    ret z 
-    
+    ret z
+
     jr .writeByte ; keep going
 
-; HL - address pointing to a table of colors 
+; HL - address pointing to a table of colors
 ; A - palette byte to start writing at (each palette is eight bytes, two for each of the four colors, and there are eight palettes)
-; B - number of bytes to write    
+; B - number of bytes to write
 GBCApplySpritePalettes:
     ; We use auto-increment for simplicity
     or %10000000
-    
-    ld [GBC_SPRITE_PALETTE_INDEX], a 
-    
+
+    ld [GBC_SPRITE_PALETTE_INDEX], a
+
     di ; To prevent an interrupt for interrupting while we try to write to VRAM in the limited time we have
-    
-.writeByte:    
+
+.writeByte:
     WaitForNonBusyLCD ; Unlike background palettes, sprite palettes can only be written during H-Blank
     ld a, [hl]
-    ld [GBC_SPRITE_PALETTE], a 
-    inc hl 
-    
+    ld [GBC_SPRITE_PALETTE], a
+    inc hl
+
     ; Have we finished writing?
-    dec b 
-    ld a, b 
+    dec b
+    ld a, b
     cp 0 ; Is B equal to zero?
-    jr z, .finish 
-    
+    jr z, .finish
+
     jr .writeByte ; keep going
 
 .finish:
-    ei 
-    ret 
+    ei
+    ret
 
-ENDC ; End of GBC functionality    
-    
+ENDC ; End of GBC functionality
+
 ; --- Super Game Boy functionality ---
 IF DEF(SGB_SUPPORT)
 
@@ -808,8 +808,6 @@ SGB_FREEZE:
 DB %10111001    ; MASK_EN command, length one
 DB 1            ; Freeze current image
 DB 0
-DB 0 
-DB 0 
 DB 0
 DB 0
 DB 0
@@ -820,9 +818,11 @@ DB 0
 DB 0
 DB 0
 DB 0
-DB 0 
+DB 0
+DB 0
+DB 0
 
-SGB_UNFREEZE:   
+SGB_UNFREEZE:
 DB %10111001    ; MASK_EN command, length one
 DB 0            ; Unfreeze
 DB 0
@@ -838,11 +838,10 @@ DB 0
 DB 0
 DB 0
 DB 0
-DB 0 
+DB 0
 
 SGB_MLTREQ1:
 DB %10001001
-DB 0 
 DB 0
 DB 0
 DB 0
@@ -856,7 +855,8 @@ DB 0
 DB 0
 DB 0
 DB 0
-DB 0  
+DB 0
+DB 0
 
 SGB_MLTREQ2:
 DB %10001001
@@ -873,62 +873,62 @@ DB 0
 DB 0
 DB 0
 DB 0
-DB 0  
-DB 0  
+DB 0
+DB 0
 
 SGB_VRAMTRANS_TILEDATA1:
 DB %10011001	; CHR_TRN, length one
 DB 0 			; lower tiles (we can have another set of 128 tiles by setting this to one)
 DB 0
-DB 0 
-DB 0 
-DB 0 
-DB 0 
-DB 0 
-DB 0 
-DB 0 
-DB 0 
-DB 0 
-DB 0 
-DB 0 
-DB 0  
-DB 0  
+DB 0
+DB 0
+DB 0
+DB 0
+DB 0
+DB 0
+DB 0
+DB 0
+DB 0
+DB 0
+DB 0
+DB 0
+DB 0
 
 SGB_VRAMTRANS_TILEDATA2:
 DB %10011001	; CHR_TRN, length one
-DB 1 			; upper tiles 
+DB 1 			; upper tiles
 DB 0
-DB 0 
-DB 0 
-DB 0 
-DB 0 
-DB 0 
-DB 0 
-DB 0 
-DB 0 
-DB 0 
-DB 0 
-DB 0 
-DB 0  
-DB 0 
+DB 0
+DB 0
+DB 0
+DB 0
+DB 0
+DB 0
+DB 0
+DB 0
+DB 0
+DB 0
+DB 0
+DB 0
+DB 0
 
 SGB_VRAMTRANS_TILEMAP:
 DB %10100001	; PCT_TRN, length one
-DB 0 			
 DB 0
-DB 0 
-DB 0 
-DB 0 
-DB 0 
-DB 0 
-DB 0 
-DB 0 
-DB 0 
-DB 0 
-DB 0 
-DB 0 
-DB 0  
-DB 0  
+DB 0
+DB 0
+DB 0
+DB 0
+DB 0
+DB 0
+DB 0
+DB 0
+DB 0
+DB 0
+DB 0
+DB 0
+DB 0
+DB 0
 
 ; According to some sources, these commands should be sent to the SGB as an initialization. It doesn't seem mandatory though?
 SGB_INIT1:
@@ -948,7 +948,7 @@ DB $79,$1B,$08,$00,$0B,$EA,$EA,$EA,$EA,$EA,$A9,$01,$CD,$4F,$0C,$D0
 SGB_INIT8:
 DB $79,$10,$08,$00,$0B,$4C,$20,$08,$EA,$EA,$EA,$EA,$EA,$60,$EA,$EA
 
-SECTION "SGB commands on bank0",ROM0 
+SECTION "SGB commands on bank0",ROM0
 SGBAbsolutelyFirstInit:
     call SGBStrangeInit
     ret
@@ -956,60 +956,60 @@ SGBAbsolutelyFirstInit:
 CheckIfSGB:
     call CheckSGB
     jr nc, .CISGB_notSGB
-    
+
     ; If we get here, then we are running SGB
-    ld a, 1 
-    ld [RUNNING_ON_SGB], a 
+    ld a, 1
+    ld [RUNNING_ON_SGB], a
     jr .CISGB_end
-    
+
 .CISGB_notSGB
-    xor a 
-    ld [RUNNING_ON_SGB], a 
-    
+    xor a
+    ld [RUNNING_ON_SGB], a
+
     jr .CISGB_end
-    
+
 .CISGB_end
     ret
 
-SGBEarlyExit: MACRO 
+SGBEarlyExit: MACRO
     ld a, [RUNNING_ON_SGB]
-    cp 0 
-    ret z 
+    cp 0
+    ret z
 ENDM
-    
+
 SECTION "SGB commands on bank1",ROMX,BANK[1]
 
 SGBStrangeInit:
-    ld hl, SGB_INIT1 
+    ld hl, SGB_INIT1
     call SGBSendData
-    
+
     ld hl, SGB_INIT2
     call SGBSendData
-    
-    ld hl, SGB_INIT3 
+
+    ld hl, SGB_INIT3
     call SGBSendData
-    
-    ld hl, SGB_INIT4 
+
+    ld hl, SGB_INIT4
     call SGBSendData
-    
+
     ld hl, SGB_INIT5
     call SGBSendData
-    
-    ld hl, SGB_INIT6 
+
+    ld hl, SGB_INIT6
     call SGBSendData
-    
-    ld hl, SGB_INIT7 
+
+    ld hl, SGB_INIT7
     call SGBSendData
-    
-    ld hl, SGB_INIT8 
+
+    ld hl, SGB_INIT8
     call SGBSendData
-    
-    ret 
+
+    ret
 
 SGBBorderTransferMacro: MACRO
     di
     call StopLCD
-	
+
     ld hl, \1
     ld de, TILEDATA_START
     ld bc, 4096
@@ -1019,27 +1019,27 @@ SGBBorderTransferMacro: MACRO
     ld de, BACKGROUND_MAPDATA_START
     ld bc, 32*32
     call mCopyVRAM
-    
+
     call StartLCD
-   
+
     halt
-    
+
     ld hl, \2
     call SGBSendData
 
-    ei 
-    
-REPT 5	
+    ei
+
+REPT 5
     halt
-ENDR	
+ENDR
 
 ENDM
 
 SGBFreeze:
     ld hl, SGB_FREEZE
     call SGBSendData
-    ret 
-    
+    ret
+
 SGBUnfreeze:
     ld hl, SGB_UNFREEZE
     call SGBSendData
@@ -1047,91 +1047,91 @@ SGBUnfreeze:
 
 ; Input: HL - address to first byte to send
 SGBSendData:
-    di 
-    ; Register use: 
+    di
+    ; Register use:
     ; B - Byte currently sending
-    ; C - Total number of bytes to send 
-    ; D - Number of bits sent of current byte 
+    ; C - Total number of bytes to send
+    ; D - Number of bits sent of current byte
 
     ld a, [hl]
-    ld b, a 
-    
-    ; Each packet should send 16 bytes 
+    ld b, a
+
+    ; Each packet should send 16 bytes
     ld c, 16
-    
-    xor a 
-    ld d, a 
-    
-    ; Prepare SGB for listening 
-    ld a, SGB_SEND_RESET
-    ld [SGB_OUT_ADDRESS], a 
-    
-    ld a, SGB_SEND_NULL
-    ld [SGB_OUT_ADDRESS], a 
-     
-SGBSendBit:
-    inc d 
-    ld a, d 
-    cp 9 
-    jr z, SGBEndOfByte
 
-    ld a, b 
-    and %00000001
-    cp 0 
-    jr z, SGBSendZeroBit
-    
-    ; Send a ONE bit here 
-    ld a, SGB_SEND_ONE
-    ld [SGB_OUT_ADDRESS], a 
-    jr SGBSendBitEnd
-    
-SGBSendZeroBit:
-    ld a, SGB_SEND_ZERO
-    ld [SGB_OUT_ADDRESS], a 
-    
-SGBSendBitEnd:
-    ; Both P14 and P15 should be HIGH in between sent bits 
-    ld a, SGB_SEND_NULL 
-    ld [SGB_OUT_ADDRESS], a 
-        
-    ld a, b 
-    sra a 
-    and %01111111
-    ld b, a 
-    
-    jr SGBSendBit
-    
-SGBEndOfByte:
-    dec c 
-    ld a, c 
-    cp 0 
-    jr z, SGBFinalEnd
-    
-    ; If there are still bytes to send, we get here 
-    inc hl 
-    ld a, [hl]
-    ld b, a 
-    
-    xor a 
-    ld d, a 
-    
-    jr SGBSendBit
-    
-SGBFinalEnd:
-    call SGBFinish 
-    ret 
-    
-SGBFinish:
-    ld a, SGB_SEND_ZERO
-    ld [SGB_OUT_ADDRESS], a 
-    
+    xor a
+    ld d, a
+
+    ; Prepare SGB for listening
+    ld a, SGB_SEND_RESET
+    ld [SGB_OUT_ADDRESS], a
+
     ld a, SGB_SEND_NULL
     ld [SGB_OUT_ADDRESS], a
-    
+
+SGBSendBit:
+    inc d
+    ld a, d
+    cp 9
+    jr z, SGBEndOfByte
+
+    ld a, b
+    and %00000001
+    cp 0
+    jr z, SGBSendZeroBit
+
+    ; Send a ONE bit here
+    ld a, SGB_SEND_ONE
+    ld [SGB_OUT_ADDRESS], a
+    jr SGBSendBitEnd
+
+SGBSendZeroBit:
+    ld a, SGB_SEND_ZERO
+    ld [SGB_OUT_ADDRESS], a
+
+SGBSendBitEnd:
+    ; Both P14 and P15 should be HIGH in between sent bits
+    ld a, SGB_SEND_NULL
+    ld [SGB_OUT_ADDRESS], a
+
+    ld a, b
+    sra a
+    and %01111111
+    ld b, a
+
+    jr SGBSendBit
+
+SGBEndOfByte:
+    dec c
+    ld a, c
+    cp 0
+    jr z, SGBFinalEnd
+
+    ; If there are still bytes to send, we get here
+    inc hl
+    ld a, [hl]
+    ld b, a
+
+    xor a
+    ld d, a
+
+    jr SGBSendBit
+
+SGBFinalEnd:
+    call SGBFinish
+    ret
+
+SGBFinish:
+    ld a, SGB_SEND_ZERO
+    ld [SGB_OUT_ADDRESS], a
+
+    ld a, SGB_SEND_NULL
+    ld [SGB_OUT_ADDRESS], a
+
     ei
     call Wait7000
-    ret 
-    
+    ret
+
 Wait7000:
     ld de, 7000 ; Each loop takes 9 cycles so this routine actually waits 63000 cycles.
 .loop
@@ -1143,7 +1143,7 @@ Wait7000:
 	or e
 	jr nz, .loop
 	ret
-    
+
 CheckSGB:
 ; Returns whether the game is running on an SGB in carry.
 	ld hl, SGB_MLTREQ2
@@ -1194,16 +1194,16 @@ CheckSGB:
 .isSGB
 	call SendMltReq1Packet
 	scf
-	ret    
+	ret
 
 SendMltReq1Packet:
     ld hl, SGB_MLTREQ1
     call SGBSendData
     jp Wait7000
 
-ENDC ; End of Super Game Boy functionality 
+ENDC ; End of Super Game Boy functionality
 
-    
+
 ; --- Boot process and interrupts ---
 ; Feel free to change interrupts if your game should use them
 
@@ -1219,18 +1219,18 @@ SECTION	"Serial interrupt",ROM0[$0058]
 SECTION	"p1234 interrupt",ROM0[$0060]
     reti
 
-; These are the first lines the boot loader will run. 
+; These are the first lines the boot loader will run.
 SECTION	"GingerBread start",ROM0[$0100]
     nop
-    
+
 IF DEF(GBC_SUPPORT)
     jp CheckIfGBC
     ; This jumps to GingerBreadBegin
 ELSE
     jp GingerBreadBegin
 ENDC
-    
-SECTION "GingerBread Technical stuff, DMA and stop/start LCD",ROM0    
+
+SECTION "GingerBread Technical stuff, DMA and stop/start LCD",ROM0
 initdma:
 	ld	de, DMACODE_START
 	ld	hl, dmacode
@@ -1248,11 +1248,11 @@ dma_wait:
 	pop	af
 	reti
 dmaend:
-    nop 
-    
+    nop
+
 StopLCD:
     ld a, [rLCDC]
-    rlca  
+    rlca
     ret nc ; In this case, the LCD is already off
 
 .wait:
@@ -1261,24 +1261,24 @@ StopLCD:
     jr nz, .wait
 
     ld  a, [rLCDC]
-    res 7, a 
+    res 7, a
     ld  [rLCDC], a
 
     ret
 
 StartLCD:
-    ; Turns on LCD with reasonable settings (with 8x16 sprites!) 
-    ; It makes the background map be at $9800-$9BFF, while the window (which is off) be at $9C00-9FFF, which 
+    ; Turns on LCD with reasonable settings (with 8x16 sprites!)
+    ; It makes the background map be at $9800-$9BFF, while the window (which is off) be at $9C00-9FFF, which
     ; is consistent with the definitions of BACKGROUND_MAPDATA_START and WINDOW_MAPDATA_START
     ld	a, LCDCF_ON|LCDCF_BG8000|LCDCF_BG9800|LCDCF_BGON|LCDCF_OBJ16|LCDCF_OBJON|LCDCF_WIN9C00|LCDCF_WINOFF
 	ld	[rLCDC], a
-    ret     
-    
+    ret
+
 TurnOnWindow:
     ; Same as StartLCD except the window is on. Turn it off by calling StartLCD (which doesn't hurt calling even when the LCD is already on)
     ld	a, LCDCF_ON|LCDCF_BG8000|LCDCF_BG9800|LCDCF_BGON|LCDCF_OBJ16|LCDCF_OBJON|LCDCF_WIN9C00|LCDCF_WINON
 	ld	[rLCDC], a
-    ret    
+    ret
 
 SECTION "GingerBread boot",ROMX
 
@@ -1289,68 +1289,67 @@ CheckIfGBC:
 
     ; If we get here, we are running on a GBC (or GBA)
 .isGBC:
-    ld a, 1 
-    ld [RUNNING_ON_GBC], a 
-    jr GingerBreadBegin  
-    
+    ld a, 1
+    ld [RUNNING_ON_GBC], a
+    jr GingerBreadBegin
+
 .notGBC:
-    xor a 
-    ld [RUNNING_ON_GBC], a 
-    jr GingerBreadBegin  
+    xor a
+    ld [RUNNING_ON_GBC], a
+    jr GingerBreadBegin
 ENDC
-    
+
 ; This function is called right at the start of the game. Calling or jumping to this function later should be equivalent to resetting the game.
 ; It resets RAM and various graphical settings.
 GingerBreadBegin:
-    nop 
+    nop
     di
-    
+
     ; Initialize stack pointer
-    ld	sp, $ffff 
-    
-    ; Reset RAM 
+    ld	sp, $ffff
+
+    ; Reset RAM
     ld hl, USER_RAM_START
     ld bc, $0FFF
-    xor a 
-    call mSet 
-    
+    xor a
+    call mSet
+
 IF DEF(SGB_SUPPORT)
     call SGBAbsolutelyFirstInit
     call CheckIfSGB
-ENDC    
-    
+ENDC
+
     ; Initialize display
     call StopLCD
     call initdma
-    
+
     ld	a, IEF_VBLANK ; We only want vblank interrupts (for updating sprites)
-    ld	[rIE], a 
-    
+    ld	[rIE], a
+
     ei
-    
-    ; Reset VRAM 
+
+    ; Reset VRAM
     ld hl, TILEDATA_START
     ld bc, $1FFF
-    xor a 
-    call mSet 
-    
+    xor a
+    call mSet
+
     ; Set default palettes
     ld a, %11100100
     ld [BG_PALETTE], a
     ld [SPRITE_PALETTE_1], a
-    ld [SPRITE_PALETTE_2], a 
-    
+    ld [SPRITE_PALETTE_2], a
+
     ; Reset sprites
     ld   hl, SPRITES_START
     ld   bc, SPRITES_LENGTH
-    xor a 
+    xor a
     call mSet
-    
+
     ; Set background position (no scrolling)
-    xor a 
-    ld [SCROLL_X], a 
-    ld [SCROLL_Y], a 
+    xor a
+    ld [SCROLL_X], a
+    ld [SCROLL_Y], a
 
-    jp begin ; GingerBread assumes that your game has this label somewhere where your own code should start 
+    jp begin ; GingerBread assumes that your game has this label somewhere where your own code should start
 
-    


### PR DESCRIPTION
I'm new to assembly & gameboy programming. Thank you so much for writing this book, it's been very helpful for getting me up to speed!

I think I found a bug in RenderTextToLengthByPosition: the comment says HL is stored in DE, but the code seems to store HE in DL, which I think is an error, but I'm not 100% confident I'm not missing something. 

My editor setup also automatically trims trailing whitespace, so I included that as a separate commit. Let me know if you'd like me to remove it.